### PR TITLE
refresh method

### DIFF
--- a/src/components/ChatSideBar.tsx
+++ b/src/components/ChatSideBar.tsx
@@ -4,7 +4,7 @@ import { Button } from './ui/button';
 import { MessageCircle, PlusCircle, Trash2 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import GoPro from './GoPro';
 import {
@@ -74,6 +74,9 @@ const ChatSideBar = ({ chats, chatId, isPro }: Props) => {
       setIsDeleting(false);
     }
   };
+  useEffect(() => {
+    router.refresh();
+  }, [chatId, router]);
   return (
     <div className="w-full h-screen p-4 text-gray-200 bg-gray-900 flex flex-col">
       <Dialog>

--- a/src/data/logs/updateEntries.ts
+++ b/src/data/logs/updateEntries.ts
@@ -31,6 +31,10 @@ const updateLogEntries: LogEntry[] = [
       'synchronization bug fix',
     ],
   },
+  {
+    date: '31/10/2023',
+    updates: ['Fix the ChatList update problem'],
+  },
   // ...more entries
 ];
 


### PR DESCRIPTION
This branch is use to solve the chatList synchronize problem. Since the page is server rendering, when user delete or create a page and navigate back to the previouse one. The chat that recently change would not appear or disappear as plan, except refresh page manually. Because the function that fetch recent list would not run when switching between chats.
/*********************/
I have no idea how to balance between server rendering and user State management. They either cost too high, or doesn't work at all.
Finally have to auto refresh the page for updateing the chatList, thansk for speed of Internet today, it most can not be noticed.